### PR TITLE
Add Sidebar for logged-in users

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import './shared/buttons';
 @import './shared/links';
 @import './shared/pagination';
+@import './shared/sidebar';

--- a/app/assets/stylesheets/shared/_sidebar.scss
+++ b/app/assets/stylesheets/shared/_sidebar.scss
@@ -1,0 +1,15 @@
+.sidebar {
+  @apply hidden md:block w-44 h-screen mr-4 bg-gray-100 flex flex-col p-2;
+
+  .sidebar-link {
+    @apply mb-5;
+  }
+
+  .sidebar-link.active {
+    @apply border-r-2 border-gray-900;
+  }
+
+  .sidebar-link:hover {
+    @apply border-r-2 border-gray-300;
+  }
+}

--- a/app/assets/stylesheets/shared/_sidebar.scss
+++ b/app/assets/stylesheets/shared/_sidebar.scss
@@ -1,5 +1,5 @@
 .sidebar {
-  @apply hidden md:block w-44 h-screen mr-4 bg-gray-100 flex flex-col p-2;
+  @apply hidden md:block w-44 h-auto mr-4 bg-gray-100 flex flex-col p-2;
 
   .sidebar-link {
     @apply mb-5;

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -1,5 +1,6 @@
 class DevicesController < ApplicationController
   before_action :load_device, only: %i(edit update destroy)
+  before_action :set_sidebar_entry, only: %i[new edit]
 
   def index
     @devices = current_user.devices.order(updated_at: :desc, last_seen_at: :desc)
@@ -44,5 +45,9 @@ class DevicesController < ApplicationController
 
   def load_device
     @device = current_user.devices.find(params[:id])
+  end
+
+  def set_sidebar_entry
+    @sidebar_entry = 'Devices'
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,6 +4,7 @@ class EventsController < ApplicationController
   before_action :load_device, only: :index
 
   def index
+    @sidebar_entry = 'Devices'
     @pagy, @events = pagy(@device.events.order(timestamp: :desc))
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def sidebar_link_active?(link_text, link_path)
+    @sidebar_entry ? @sidebar_entry == link_text : current_page?(link_path)
+  end
 end

--- a/app/views/devices/_form.html.erb
+++ b/app/views/devices/_form.html.erb
@@ -1,4 +1,4 @@
-<div class='flex justify-center mt-8'>
+<div class='flex h-48 justify-center mt-8'>
   <%= form_for(device, class: 'form-horizontal', html: { class: 'w-full sm:max-w-md bg-gray-100 z-10 shadow-md rounded p-8' }) do |form| %>
     <% if device.persisted? %>
       <div class='flex items-center mb-3'>

--- a/app/views/devices/index.html.erb
+++ b/app/views/devices/index.html.erb
@@ -1,60 +1,62 @@
 <% content_for(:title, "Mimir - Devices") %>
 
-<% if @devices.none? %>
-  <div class='m-4 p-2 flex flex-row'>
-    <div class='mx-auto'>
-      It doesn't look like you have any devices configured.
-      You can <%= link_to 'add a new device', new_device_path, class: 'link' %>
+<div class='flex flex-col'>
+  <% if @devices.none? %>
+    <div class='m-4 p-2 flex flex-row'>
+      <div class='mx-auto'>
+        It doesn't look like you have any devices configured.
+        You can <%= link_to 'add a new device', new_device_path, class: 'link' %>
       to get started.
-    </div>
-  </div>
-<% end %>
-
-<div class='flex flex-col mt-8'>
-  <% @devices.each do |device| %>
-    <div class='md:mx-auto mb-8 sm:flex'>
-      <div class='sm:min-w-lg p-4 sm:pb-8 bg-gray-100 shadow-md rounded'>
-        <div class='flex justify-between border-b-2 border-black'>
-          <p class='font-semibold text-sm'><%= device.name %>
-          <p class='font-thin text-xs'><%= device_last_seen(device) %></p>
-        </div>
-        <div class='pt-4'>
-          <div class='flex justify-between'>
-            <p class='md:w-64 font-semibold text-sm'>UUID</p>
-            <p class='font-thin text-xs'><%= device.uuid %></p>
-          </div>
-        </div>
-        <div>
-          <div class='flex justify-between border-b-2 border-black'>
-            <p class='font-semibold text-sm'>Auth Token</p>
-            <p class='font-thin text-xs'><%= device.user.auth_token %></p>
-          </div>
-        </div>
-        <div class='pt-4'>
-          <div class='pb-1 flex justify-between'>
-            <p class='text-sm font-semibold'>Newest events</p>
-            <p class='font-thin text-xs'><%= pluralize(device.events.count, "total event") %></p>
-          </div>
-          <ul class='w-full whitespace-no-wrap overflow-auto'>
-            <% newest_events_for_device(device).each do |event| %>
-              <li class='sm:flex sm:justify-between'>
-                <span class='text-xs font-hairline sm:mr-4'><%= event.description %></span>
-                <span class='text-xs font-hairline'><%= event.timestamp.in_time_zone(current_user.time_zone) %></span>
-              </li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-      <div class='pt-2 ml-2 mr-2 sm:p-0 flex sm:flex-col justify-between'>
-        <div>
-          <%= link_to('+ Device', new_device_path, class: 'button-primary inline-block sm:block mb-2') %>
-          <%= link_to('Edit', edit_device_path(device), class: 'button-secondary inline-block sm:block mb-2') %>
-          <%= link_to('Events', device_events_path(device), class: 'button inline-block sm:block') %>
-        </div>
-        <div>
-          <%= link_to('Delete', device_path(device), method: :delete, data: { confirm: 'Are you sure?'}, class: 'button-danger inline-block sm:block') %>
-        </div>
       </div>
     </div>
   <% end %>
+
+  <div class='flex flex-col mt-8'>
+    <% @devices.each do |device| %>
+      <div class='md:mx-auto mb-8 sm:flex'>
+        <div class='sm:min-w-lg p-4 sm:pb-8 bg-gray-100 shadow-md rounded'>
+          <div class='flex justify-between border-b-2 border-black'>
+            <p class='font-semibold text-sm'><%= device.name %>
+            <p class='font-thin text-xs'><%= device_last_seen(device) %></p>
+          </div>
+          <div class='pt-4'>
+            <div class='flex justify-between'>
+              <p class='md:w-64 font-semibold text-sm'>UUID</p>
+              <p class='font-thin text-xs'><%= device.uuid %></p>
+            </div>
+          </div>
+          <div>
+            <div class='flex justify-between border-b-2 border-black'>
+              <p class='font-semibold text-sm'>Auth Token</p>
+              <p class='font-thin text-xs'><%= device.user.auth_token %></p>
+            </div>
+          </div>
+          <div class='pt-4'>
+            <div class='pb-1 flex justify-between'>
+              <p class='text-sm font-semibold'>Newest events</p>
+              <p class='font-thin text-xs'><%= pluralize(device.events.count, "total event") %></p>
+            </div>
+            <ul class='w-full whitespace-no-wrap overflow-auto'>
+              <% newest_events_for_device(device).each do |event| %>
+                <li class='sm:flex sm:justify-between'>
+                  <span class='text-xs font-hairline sm:mr-4'><%= event.description %></span>
+                  <span class='text-xs font-hairline'><%= event.timestamp.in_time_zone(current_user.time_zone) %></span>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+        <div class='pt-2 ml-2 mr-2 sm:p-0 flex sm:flex-col justify-between'>
+          <div>
+            <%= link_to('+ Device', new_device_path, class: 'button-primary inline-block sm:block mb-2') %>
+            <%= link_to('Edit', edit_device_path(device), class: 'button-secondary inline-block sm:block mb-2') %>
+            <%= link_to('Events', device_events_path(device), class: 'button inline-block sm:block') %>
+          </div>
+          <div>
+            <%= link_to('Delete', device_path(device), method: :delete, data: { confirm: 'Are you sure?'}, class: 'button-danger inline-block sm:block') %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, "Mimir - Edit Profile") %>
 
-<div class='flex justify-center mt-8'>
+<div class='flex justify-center mt-4'>
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: 'w-full sm:max-w-lg bg-gray-100 z-10 shadow-md rounded p-8' }) do |f| %>
     <div class='flex items-center mb-3'>
       <div class='w-1/3'>
@@ -39,8 +39,10 @@
     </div>
 
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
-  <% end %>
+      <div class='flex items-center mb-3'>
+        Currently waiting confirmation for: <%= resource.unconfirmed_email %>
+      </div>
+    <% end %>
 
   <div class='flex items-center mb-3'>
     <div class='w-1/3'>
@@ -50,7 +52,6 @@
       <%= f.password_field :current_password, autocomplete: "off", placeholder: 'your current password', class: 'border rounded w-full appearance-none text-sm text-gray-700' %>
     </div>
   </div>
-
 
   <div class='flex items-center mb-3'>
     <div class='w-1/3'>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,34 +1,36 @@
 <% content_for(:title, "Mimir - Device Events") %>
 
-<div class='sm:w-full sm:flex sm:justify-center p-4'>
-  <table class='table-fixed overflow-auto text-sm'>
-    <thead>
-      <tr class='text-justify text-xs'>
-        <th class='p-2 hidden md:table-cell'>Command</th>
-        <th class='p-2 hidden md:table-cell'>Data</th>
-        <th class='p-2'>Description</th>
-        <th class='p-2'>Timestamp</th>
-        <th class='p-2'>Priority</th>
-        <th class='p-2 hidden md:table-cell'>Partition</th>
-        <th class='p-2 hidden md:table-cell'>Zone</th>
-      </tr>
-    </thead>
-    <tbody class="border">
-      <% @events.each do |event| %>
-        <tr class='text-xs odd:bg-gray-100'>
-          <td class='md:p-2 hidden md:table-cell'><%= event.command %></td>
-          <td class='md:p-2 hidden md:table-cell'><%= event.data %></td>
-          <td class='md:p-2'><%= event.description %></td>
-          <td class='md:p-2'><%= event.timestamp.in_time_zone(current_user.time_zone).to_s(:long) %></td>
-          <td class='md:p-2'><%= event.priority %></td>
-          <td class='md:p-2 hidden md:table-cell'><%= event.partition %></td>
-          <td class='md:p-2 hidden md:table-cell'><%= event.zone %></td>
+<div class='flex flex-col'>
+  <div class='sm:w-full sm:flex sm:justify-center m-4 p-2'>
+    <table class='table-fixed overflow-auto text-sm'>
+      <thead>
+        <tr class='text-justify text-xs'>
+          <th class='p-2 hidden md:table-cell'>Command</th>
+          <th class='p-2 hidden md:table-cell'>Data</th>
+          <th class='p-2'>Description</th>
+          <th class='p-2'>Timestamp</th>
+          <th class='p-2'>Priority</th>
+          <th class='p-2 hidden md:table-cell'>Partition</th>
+          <th class='p-2 hidden md:table-cell'>Zone</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
-</div>
+      </thead>
+      <tbody class="border">
+        <% @events.each do |event| %>
+          <tr class='text-xs odd:bg-gray-100'>
+            <td class='md:p-2 hidden md:table-cell'><%= event.command %></td>
+            <td class='md:p-2 hidden md:table-cell'><%= event.data %></td>
+            <td class='md:p-2'><%= event.description %></td>
+            <td class='md:p-2'><%= event.timestamp.in_time_zone(current_user.time_zone).to_s(:long) %></td>
+            <td class='md:p-2'><%= event.priority %></td>
+            <td class='md:p-2 hidden md:table-cell'><%= event.partition %></td>
+            <td class='md:p-2 hidden md:table-cell'><%= event.zone %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 
-<div class='w-auto text-sm text-center'>
-  <%== pagy_nav(@pagy) %>
+  <div class='w-auto text-sm text-center'>
+    <%== pagy_nav(@pagy) %>
+  </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,12 +14,14 @@
     <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/alerts' %>
 
-    <div class='flex flex-row'>
+    <div class='h-screen flex flex-row'>
       <%= render partial: 'shared/sidebar' %>
 
-      <%= yield %>
+      <div class='w-full justify-center'>
+        <%= yield %>
+      </div>
+    </div>
 
-      <%= render partial: 'shared/footer' %>
-    <div>
+    <%= render partial: 'shared/footer' %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,12 @@
     <%= render partial: 'shared/header' %>
     <%= render partial: 'shared/alerts' %>
 
-    <%= yield %>
+    <div class='flex flex-row'>
+      <%= render partial: 'shared/sidebar' %>
 
-    <%= render partial: 'shared/footer' %>
+      <%= yield %>
+
+      <%= render partial: 'shared/footer' %>
+    <div>
   </body>
 </html>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     <% if user_signed_in? %>
       <div class='flex items-center text-gray-100'>
         <%= link_to('Profile', edit_user_registration_path(current_user), class: 'px-1 py-1 block rounded hover:bg-teal-800') %>
-        <%= link_to('Devices', devices_path, class: 'px-1 py-1 block rounded hover:bg-teal-800') %>
+        <%= link_to('Devices', devices_path, class: 'px-1 py-1 md:hidden block rounded hover:bg-teal-800') %>
         <%= link_to('Logout', destroy_user_session_path, method: :delete, class: 'px-1 py-1 md:ml-4 ml-2 block rounded border border-gray-200 border-dotted hover:bg-teal-800') %>
       </div>
     <% end %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,6 +1,8 @@
-<div class='sidebar'>
-  <ul class='mt-2 flex flex-col mt-4 p-2'>
-    <li class="sidebar-link <%= 'active' if sidebar_link_active?('Home', root_path) %>"><%= link_to 'Home', root_path %></li>
-    <li class="sidebar-link <%= 'active' if sidebar_link_active?('Devices', devices_path) %>"><%= link_to 'Devices', devices_path %></li>
-  </ul>
-</div>
+<% if signed_in? %>
+  <div class='sidebar'>
+    <ul class='flex flex-col mt-4 p-2'>
+      <li class="sidebar-link <%= 'active' if sidebar_link_active?('Home', root_path) %>"><%= link_to 'Home', root_path %></li>
+      <li class="sidebar-link <%= 'active' if sidebar_link_active?('Devices', devices_path) %>"><%= link_to 'Devices', devices_path %></li>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,0 +1,6 @@
+<div class='sidebar'>
+  <ul class='mt-2 flex flex-col mt-4 p-2'>
+    <li class="sidebar-link <%= 'active' if sidebar_link_active?('Home', root_path) %>"><%= link_to 'Home', root_path %></li>
+    <li class="sidebar-link <%= 'active' if sidebar_link_active?('Devices', devices_path) %>"><%= link_to 'Devices', devices_path %></li>
+  </ul>
+</div>


### PR DESCRIPTION
Add a simple sidebar for logged-in users with two links for now, one for `Devices` and one for `Home`.

The goal is to add more links to this one instead of adding them to the top navigation bar but since screen real-estate is limited on mobile, don't show the sidebar for mobile devices.